### PR TITLE
Make dotnet-service work on net7.0 runtime

### DIFF
--- a/part0/services/dotnet-service/Startup.cs
+++ b/part0/services/dotnet-service/Startup.cs
@@ -1,53 +1,57 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
 using Prometheus;
-using Swashbuckle.AspNetCore.Swagger;
 
 namespace dotnetservice
 {
-  public class Startup
-  {
-    public Startup(IConfiguration configuration)
+    public class Startup
     {
-      Configuration = configuration;
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMetricServer();
+            app.UseHttpMetrics();
+
+            app.UseSwagger();
+
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+            });
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
     }
-
-    public IConfiguration Configuration { get; }
-
-    // This method gets called by the runtime. Use this method to add services to the container.
-    public void ConfigureServices(IServiceCollection services)
-    {
-      services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-
-      services.AddSwaggerGen(c =>
-          {
-          c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
-          });
-    }
-
-    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-    {
-      if (env.IsDevelopment())
-      {
-        app.UseDeveloperExceptionPage();
-      }
-
-      app.UseMetricServer();
-      app.UseHttpMetrics();
-
-      app.UseSwagger();
-
-      app.UseSwaggerUI(c =>
-          {
-          c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-          });
-
-      app.UseMvc();
-
-    }
-  }
 }

--- a/part0/services/dotnet-service/dotnet-service.csproj
+++ b/part0/services/dotnet-service/dotnet-service.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="Current">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>dotnet-servce</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.1.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Dockerfile using FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env for the dotnet-service application, however the app is targeted to core 2.2 which is depreciated and running a container will result in exit code 139. 

Modified some of the nuget libraries and startup configuration so it works with 7.0 runtime